### PR TITLE
Add timestamp type with optional chrono support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         rust: [stable]
+        features: ["", "--features chrono"]
     steps:
       - uses: actions/checkout@v5.0.0
         with:
@@ -47,4 +48,4 @@ jobs:
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           toolchain: ${{ matrix.rust }}
-      - run: cargo test --all-features
+      - run: cargo test ${{ matrix.features }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,11 @@ rust-version = "1.91.0"
 bytes = "1.11.0"
 thiserror = "2.0.17"
 relish_derive = { path = "relish_derive" }
+chrono = { version = "0.4", optional = true, default-features = false, features = ["std"] }
+
+[features]
+default = []
+chrono = ["dep:chrono"]
 
 [workspace]
 members = ["relish_derive"]

--- a/SPEC.md
+++ b/SPEC.md
@@ -53,6 +53,7 @@ Varsize types use a tagged varint encoding for length prefixes:
 | Map | 0x10 | Varsize |
 | Struct | 0x11 | Varsize |
 | Enum | 0x12 | Varsize |
+| Timestamp | 0x13 | Fixed |
 
 ## Fixed-Size Types
 
@@ -70,6 +71,11 @@ Varsize types use a tagged varint encoding for length prefixes:
 ### Floating Point Types (f32, f64)
 - Little-endian encoded IEEE 754 bytes
 - Sizes: 4 or 8 bytes respectively
+
+### Timestamp
+- 8 bytes: little-endian encoded unsigned 64-bit Unix timestamp
+- Represents seconds since the Unix epoch (January 1, 1970, 00:00:00 UTC)
+- Does not include subsecond precision
 
 ## Varsize Types
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,6 +36,10 @@ pub enum ParseErrorKind {
 
     #[error("unknown variant ID: {0}")]
     UnknownVariant(u8),
+
+    #[cfg(feature = "chrono")]
+    #[error("invalid timestamp value: {0} (cannot be converted to DateTime)")]
+    InvalidTimestamp(u64),
 }
 
 /// Error type returned when parsing Relish binary data fails.
@@ -69,6 +73,10 @@ pub enum WriteErrorKind {
 
     #[error("content length {0} exceeds maximum allowed (u32::MAX >> 1)")]
     ContentTooLarge(usize),
+
+    #[cfg(feature = "chrono")]
+    #[error("timestamp cannot be serialized as a unix timestamp")]
+    InvalidTimestamp,
 }
 
 /// Error type returned when serializing to Relish binary format fails.


### PR DESCRIPTION
Add Timestamp (0x13) as 8-byte u64 Unix timestamp. Implement Relish for chrono::DateTime<Utc> behind chrono feature with safe conversions. CI tests both feature configurations.