### PR TITLE
Add Relish trait implementation for bytes::Bytes

### DIFF
--- a/src/buf.rs
+++ b/src/buf.rs
@@ -24,6 +24,11 @@ impl<'a> BytesRef<'a> {
             data: result,
         })
     }
+
+    /// Returns the remaining data as a zero-copy `Bytes` slice.
+    pub(crate) fn to_bytes(&self) -> bytes::Bytes {
+        self.b.slice_ref(self.data)
+    }
 }
 
 impl std::ops::Deref for BytesRef<'_> {


### PR DESCRIPTION
Implement the Relish trait for bytes::Bytes, treating it as Array[u8]. This provides an efficient way to serialize/deserialize byte buffers that is compatible with Vec<u8>.

Uses zero-copy parsing via BytesRef::to_bytes() which leverages Bytes::slice_ref() to avoid unnecessary allocations.